### PR TITLE
Bump Request Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "keywords": [],
   "dependencies" : {
     "node-promise": "0.5.8",
-    "request": "2.27.0"
+    "request": "2.69.0"
   },
   "noAnalyze": true,
   "license": "MIT",


### PR DESCRIPTION
Hello!

I humbly propose that we up the version of our dependency on ```request```. When running the provided ```mocha``` tests for the api client I uncovered that I could not use the ```NODE_DEBUG=request``` feature of the ```request``` package.

I have not observed a change to my test execution from this, so, hopefully there are no regressions.

Cheers!