### PR TITLE
This fixes an out-of-the-box test failure

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -1,3 +1,3 @@
 {
-  "api_key": "XXXX"
+  "apiKey": "XXXX"
 }


### PR DESCRIPTION
Hello again!

Given I have a fresh checkout from ```master```
And I have copied ```config.json.sample``` to ```config.json``` and filled it in with my api key
When I run ```mocha test```
Then I observe:
"""
```bash
 1) Close.io API should create, read, updated, delete and search for leads.:
     Uncaught Error: no auth mechanism defined
      at Auth.onRequest (node_modules/request/lib/auth.js:133:32)
      at Request.auth (node_modules/request/request.js:1221:14)
      at Request.init (node_modules/request/request.js:392:10)
      at new Request (node_modules/request/request.js:141:8)
      at request (node_modules/request/index.js:55:10)
      at Closeio._request (lib/close.io.js:237:3)
      at Closeio._post (lib/close.io.js:266:15)
      at Object.lead.create (lib/close.io.js:30:22)
      at Context.<anonymous> (test/close.io.js:14:18)

2) Close.io API should throw a verbose error:
     Uncaught Error: no auth mechanism defined
      at Auth.onRequest (node_modules/request/lib/auth.js:133:32)
      at Request.auth (node_modules/request/request.js:1221:14)
      at Request.init (node_modules/request/request.js:392:10)
      at new Request (node_modules/request/request.js:141:8)
      at request (node_modules/request/index.js:55:10)
      at Closeio._request (lib/close.io.js:237:3)
      at Closeio._post (lib/close.io.js:266:15)
      at Object.lead.create (lib/close.io.js:30:22)
      at Context.<anonymous> (test/close.io.js:38:18)

  3) Close.io API should create, read, update, delete opportunity statuses:
     Uncaught Error: no auth mechanism defined
      at Auth.onRequest (node_modules/request/lib/auth.js:133:32)
      at Request.auth (node_modules/request/request.js:1221:14)
      at Request.init (node_modules/request/request.js:392:10)
      at new Request (node_modules/request/request.js:141:8)
      at request (node_modules/request/index.js:55:10)
      at Closeio._request (lib/close.io.js:237:3)
      at Closeio._post (lib/close.io.js:266:15)
      at Object.status.opportunity.create (lib/close.io.js:215:24)
      at Context.<anonymous> (test/close.io.js:76:34)
```
"""

However, it looks like if I change the key from ```api_key``` to ```apiKey``` it works!

Cheers