### PR TITLE
Fix double querystring encoding

### DIFF
--- a/lib/close.io.js
+++ b/lib/close.io.js
@@ -22,7 +22,16 @@ Closeio = function(apiKey) {
         parameters._fields = options.fields;
         delete options.fields;
       }
-      parameters.query = qs.stringify(options, ' ', ':');
+      parameters.query = qs.stringify(
+        options,
+        ' ',
+        ':',
+        {
+          encodeURIComponent: function(t) {
+            return t;
+          }
+        }
+      );
       if(!parameters.query) delete parameters.query;
       return closeio._get('/lead/', parameters);
     },


### PR DESCRIPTION
The encoding of the querystring is already done inside request and we shouldn't do it while stringifying the parameters.