### PR TITLE
Switch base url to api.close.com

### DIFF
--- a/lib/close.io.js
+++ b/lib/close.io.js
@@ -296,7 +296,7 @@ Closeio.prototype._request = function(options) {
 
 Closeio.prototype._post = function(path, options) {
   options = {
-    uri: 'https://app.close.io/api/v1' + path,
+    uri: 'https://api.close.com/api/v1' + path,
     body: JSON.stringify(options),
     headers: {
       'Content-type': 'application/json'
@@ -308,7 +308,7 @@ Closeio.prototype._post = function(path, options) {
 
 Closeio.prototype._get = function(path, parameters) {
   var options = {
-    uri: 'https://app.close.io/api/v1' + path,
+    uri: 'https://api.close.com/api/v1' + path,
     method: 'GET',
     qs: parameters
   };
@@ -317,7 +317,7 @@ Closeio.prototype._get = function(path, parameters) {
 
 Closeio.prototype._put = function(path, options) {
   options = {
-    uri: 'https://app.close.io/api/v1' + path,
+    uri: 'https://api.close.com/api/v1' + path,
     body: JSON.stringify(options),
     headers: {
       'Content-type': 'application/json'
@@ -329,7 +329,7 @@ Closeio.prototype._put = function(path, options) {
 
 Closeio.prototype._delete = function(path) {
   var options = {
-    uri: 'https://app.close.io/api/v1' + path,
+    uri: 'https://api.close.com/api/v1' + path,
     method: 'DELETE'
   };
   return this._request(options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "close.io",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "close.io",
   "preferGlobal": "false",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "John Wehr <johnwehr@gmail.com>",
   "description": "",
   "contributors": [


### PR DESCRIPTION
Switching the base url to api.close.com, since app.close.io/api/v1/ is now deprecated 

@taylorbrooks -- Can you take a look at this? I don't have permissions to tag you as a reviewer. Thanks! 