### PR TITLE
Add ability to use a lead search query string instead of an itemized list of search keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,26 @@ closeio.lead.create({name: "Spider Man"})
   console.log(err);
 });
 ```
+
+**Searching for Leads**
+
+The `lead.search` method accepts either a string or a dictionary of search keywords as valid parameters.
+
+To use a string to specify your search query, pass a `query` parameter to the `lead.search` method:
+
+```javascript
+closeio.lead.search({query: 'name:"Bruce Wayne" email_address:bruce@wayneenterprises.com'})
+.then(function(search_results){
+  console.log(search_results.total_results);
+});
+```
+
+To use a dictionary of search keywords to specify your search query, structure your parameters as follows:
+```javascript
+closeio.lead.search({name: "Bruce Wayne", email_address: 'bruce@wayneenterprises.com'})
+.then(function(search_results){
+  console.log(search_results.total_results);
+});
+```
+
+**Note**: The `query` parameter will override any other search keywords present in your dictionary.

--- a/lib/close.io.js
+++ b/lib/close.io.js
@@ -21,14 +21,17 @@ var Closeio = function(apiKey) {
         parameters._fields = options.fields;
         delete options.fields;
       }
-
-      var option_keys = Object.keys(options);
-      if (option_keys.length > 0) {
-        parameters.query = '';
-        option_keys.forEach(function(option) {
-          var option_wrapper = (!/^".*"$/.test(option) && / +/.test(option)) ? '"' : '';
-          parameters.query += option_wrapper + option + option_wrapper + ':' + options[option] + ' ';
-        });
+      if ('query' in options) {
+        parameters.query = options.query;
+      } else {
+        var option_keys = Object.keys(options);
+        if (option_keys.length > 0) {
+          parameters.query = '';
+          option_keys.forEach(function(option) {
+            var option_wrapper = (!/^".*"$/.test(option) && / +/.test(option)) ? '"' : '';
+            parameters.query += option_wrapper + option + option_wrapper + ':' + options[option] + ' ';
+          });
+        }
       }
 
       return closeio._get('/lead/', parameters);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "close.io",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "close.io",
   "preferGlobal": "false",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": "John Wehr <johnwehr@gmail.com>",
   "description": "",
   "contributors": [

--- a/test/close.io.js
+++ b/test/close.io.js
@@ -125,7 +125,15 @@ describe('Close.io API', function () {
         });
     });
 
-
+    it('should search a lead by query', function () {
+      var lead_id;
+      return closeio.lead.search({ query: 'name:"John Wehr"'})
+        .then(function (data) {
+          // console.log(data)
+          assert(data.data.length > 0);
+        });
+    });
+    
     after(function () {
       return closeio.lead.delete(lead_id)
     })


### PR DESCRIPTION
Fixes #25 

In this PR, I add the ability to use a `query` parameter in `lead.search` to specify your query as a single string instead of an itemized list of search keywords. This allows you to use the `not` keyword and also allows you to copy and paste search queries directly from Close into your code if applicable. 

An example of how to use the `query` parameter: 
`closeio.lead.search({ query: 'name:"Bruce Wayne" email_address:bruce@wayneenterprises.com' })`

@taylorbrooks -- Can you please take a look? :)